### PR TITLE
Experimental support for WebSockets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       connection_pool
       goliath (>= 1.0.4)
       hiredis
-      json
       msgpack (>= 0.5.0)
       redis (>= 3.0.6)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       connection_pool
       goliath (>= 1.0.4)
       hiredis
+      json
       msgpack (>= 0.5.0)
       redis (>= 3.0.6)
 
@@ -38,6 +39,9 @@ GEM
     em-websocket (0.3.8)
       addressable (>= 2.1.1)
       eventmachine (>= 0.12.9)
+    em-websocket-client (0.1.2)
+      eventmachine
+      websocket
     eventmachine (1.0.3)
     goliath (1.0.4)
       async-rack
@@ -83,6 +87,7 @@ GEM
     thread_safe (0.3.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    websocket (1.1.4)
 
 PLATFORMS
   ruby
@@ -90,6 +95,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   em-http-request
+  em-websocket-client
   minitest (>= 5.2.0)
   minitest-reporters
   rake

--- a/lib/sinapse/keep_alive.rb
+++ b/lib/sinapse/keep_alive.rb
@@ -18,7 +18,13 @@ module Sinapse
 
       def start
         EM.add_periodic_timer(Sinapse.config.keep_alive) do
-          @queue.each { |env| env.chunked_stream_send ":\n" }
+          @queue.each do |env|
+            if env['handler']
+              env.handler.send_frame(:ping, "") if env.handler.pingable?
+            else
+              env.chunked_stream_send ":\n"
+            end
+          end
         end
       end
   end

--- a/lib/sinapse/server.rb
+++ b/lib/sinapse/server.rb
@@ -42,6 +42,7 @@ module Sinapse
 
         EM.next_tick do
           ws(env, "authentication: ok")
+          keep_alive << env
         end
       end
     end

--- a/lib/sinapse/server.rb
+++ b/lib/sinapse/server.rb
@@ -42,7 +42,7 @@ module Sinapse
         subscribe(env)
 
         EM.next_tick do
-          ws(env, "connected: ok")
+          ws(env, "authentication: ok")
         end
       end
     end

--- a/lib/sinapse/server.rb
+++ b/lib/sinapse/server.rb
@@ -4,7 +4,6 @@ require 'sinapse/config'
 require 'sinapse/keep_alive'
 require 'sinapse/cross_origin_resource_sharing'
 require 'msgpack'
-require 'json'
 
 module Sinapse
   class Server < Goliath::WebSocket
@@ -105,18 +104,14 @@ module Sinapse
 
       def push(env, message, event = nil)
         if env['handler']
-          ws(env, message, event)
+          ws(env, message)
         else
           sse(env, message, event)
         end
       end
 
-      def ws(env, data, event = nil)
-        if event
-          env.handler.send_text_frame({ event: event, data: data }.to_json)
-        else
-          env.handler.send_text_frame(data)
-        end
+      def ws(env, data)
+        env.handler.send_text_frame(data)
       end
 
       def sse(env, data, event = nil, options = {})

--- a/lib/sinapse/server.rb
+++ b/lib/sinapse/server.rb
@@ -4,6 +4,8 @@ require 'sinapse/config'
 require 'sinapse/keep_alive'
 require 'sinapse/cross_origin_resource_sharing'
 require 'msgpack'
+require 'redis'
+require 'hiredis'
 
 module Sinapse
   class Server < Goliath::WebSocket
@@ -27,7 +29,7 @@ module Sinapse
         super
       else
         EM.next_tick do
-          sse(env, :ok, :authentication, retry: Sinapse.Config.retry)
+          sse(env, :ok, :authentication, retry: Sinapse.config.retry)
           subscribe(env)
           keep_alive << env
         end
@@ -49,7 +51,7 @@ module Sinapse
 
     def on_close(env)
       close_redis(env['redis']) if env['redis']
-      keep_alive.delete(env) unless env['handler']
+      keep_alive.delete(env)
     end
 
     def on_error(env, error)

--- a/sinapse.gemspec
+++ b/sinapse.gemspec
@@ -23,11 +23,13 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'hiredis'
   gem.add_dependency 'connection_pool'
   gem.add_dependency 'msgpack', '>= 0.5.0'
+  gem.add_dependency 'json'
   gem.add_dependency 'activesupport', '>= 3.0.0'
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'em-http-request'
+  gem.add_development_dependency 'em-websocket-client'
   gem.add_development_dependency 'minitest', '>= 5.2.0'
   gem.add_development_dependency 'minitest-reporters'
 end

--- a/sinapse.gemspec
+++ b/sinapse.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'hiredis'
   gem.add_dependency 'connection_pool'
   gem.add_dependency 'msgpack', '>= 0.5.0'
-  gem.add_dependency 'json'
   gem.add_dependency 'activesupport', '>= 3.0.0'
 
   gem.add_development_dependency 'bundler'

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -98,11 +98,9 @@ describe Sinapse::Server do
         wait
 
         assert_equal 1, publish(channel_name, "payload message")
-        #assert_equal "event: #{channel_name}\ndata: payload message\n\n", client.receive
         assert_equal "data: payload message\n\n", client.receive
 
         assert_equal 1, publish(channel_name, "another message")
-        #assert_equal "event: #{channel_name}\ndata: another message\n\n", client.receive
         assert_equal "data: another message\n\n", client.receive
       end
     end
@@ -180,10 +178,5 @@ describe Sinapse::Server do
         end
       end
     end
-  end
-
-  def publish(channel, message, event = nil)
-    data = MessagePack.pack(event ? [event, message] : message)
-    redis.publish(channel, data)
   end
 end

--- a/test/server_websocket_test.rb
+++ b/test/server_websocket_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+require 'sinapse/server'
+require 'goliath/test_helper_ws'
+
+describe "Sinapse::Server::WebSocket" do
+  include Goliath::TestHelper
+  include RedisTestHelper
+
+  before do
+    EM.synchrony do
+      redis.set('sinapse:tokens:valid', '1')
+      redis.set('sinapse:tokens:empty', '2')
+      redis.sadd('sinapse:channels:1', 'user:1')
+      redis.sadd('sinapse:channels:1', 'room:2')
+      redis.sadd('sinapse:channels:1', 'room:4')
+      EM.stop_event_loop
+    end
+  end
+
+  after do
+    EM.synchrony do
+      redis.del('sinapse:tokens:valid')
+      redis.del('sinapse:tokens:empty')
+      redis.del('sinapse:channels:1')
+      EM.stop_event_loop
+    end
+  end
+
+  describe "authentication" do
+    it "sends an ok message on success" do
+      ws_connect("valid") do |client|
+        assert_equal '{"event":"authentication","data":"ok"}', client.receive.data
+      end
+    end
+
+    #it "won't authenticate with unknown token"
+    #it "won't authenticate when user has no channels"
+  end
+
+  describe "push" do
+    let(:channel_name) { 'user:1' }
+
+    it "proxies published messages" do
+      ws_connect("valid") do |client|
+        client.receive
+
+        assert_equal 1, publish(channel_name, "payload message")
+        assert_equal 'payload message', client.receive.data
+
+        assert_equal 1, publish(channel_name, "another message")
+        assert_equal 'another message', client.receive.data
+      end
+    end
+
+    it "sets channel name as event type" do
+      Sinapse::Config.stub(:channel_event, true) do
+        ws_connect("valid") do |client|
+          client.receive
+          assert_equal 1, publish(channel_name, "payload message")
+          assert_equal({ event: channel_name, data: "payload message" }.to_json, client.receive.data)
+        end
+      end
+    end
+
+    it "publishes with event type" do
+      Sinapse::Config.stub(:channel_event, true) do
+        ws_connect("valid") do |client|
+          client.receive
+          assert_equal 1, publish(channel_name, "payload", "hello:world")
+          assert_equal({ event: "hello:world", data: "payload" }.to_json, client.receive.data)
+        end
+      end
+    end
+  end
+end

--- a/test/server_websocket_test.rb
+++ b/test/server_websocket_test.rb
@@ -29,12 +29,12 @@ describe "Sinapse::Server::WebSocket" do
   describe "authentication" do
     it "sends an ok message on success" do
       ws_connect("valid") do |client|
-        assert_equal "connected: ok", client.receive.data
+        assert_equal "authentication: ok", client.receive.data
       end
     end
 
     # it "fails handshake with 401 status code for unknown token" do
-    #   TODO: how to test that?
+    #   TODO: how to test?
     # end
   end
 

--- a/test/server_websocket_test.rb
+++ b/test/server_websocket_test.rb
@@ -53,22 +53,22 @@ describe "Sinapse::Server::WebSocket" do
       end
     end
 
-    it "sets channel name as event type" do
+    it "won't set channel name as event type" do
       Sinapse::Config.stub(:channel_event, true) do
         ws_connect("valid") do |client|
           client.receive
           assert_equal 1, publish(channel_name, "payload message")
-          assert_equal({ event: channel_name, data: "payload message" }.to_json, client.receive.data)
+          assert_equal("payload message", client.receive.data)
         end
       end
     end
 
-    it "publishes with event type" do
+    it "discards specified event type" do
       Sinapse::Config.stub(:channel_event, true) do
         ws_connect("valid") do |client|
           client.receive
           assert_equal 1, publish(channel_name, "payload", "hello:world")
-          assert_equal({ event: "hello:world", data: "payload" }.to_json, client.receive.data)
+          assert_equal("payload", client.receive.data)
         end
       end
     end

--- a/test/server_websocket_test.rb
+++ b/test/server_websocket_test.rb
@@ -29,12 +29,13 @@ describe "Sinapse::Server::WebSocket" do
   describe "authentication" do
     it "sends an ok message on success" do
       ws_connect("valid") do |client|
-        assert_equal '{"event":"authentication","data":"ok"}', client.receive.data
+        assert_equal "connected: ok", client.receive.data
       end
     end
 
-    #it "won't authenticate with unknown token"
-    #it "won't authenticate when user has no channels"
+    # it "fails handshake with 401 status code for unknown token" do
+    #   TODO: how to test that?
+    # end
   end
 
   describe "push" do

--- a/test/server_websocket_test.rb
+++ b/test/server_websocket_test.rb
@@ -54,7 +54,7 @@ describe "Sinapse::Server::WebSocket" do
     end
 
     it "won't set channel name as event type" do
-      Sinapse::Config.stub(:channel_event, true) do
+      Sinapse.config.stub(:channel_event, true) do
         ws_connect("valid") do |client|
           client.receive
           assert_equal 1, publish(channel_name, "payload message")
@@ -64,12 +64,10 @@ describe "Sinapse::Server::WebSocket" do
     end
 
     it "discards specified event type" do
-      Sinapse::Config.stub(:channel_event, true) do
-        ws_connect("valid") do |client|
-          client.receive
-          assert_equal 1, publish(channel_name, "payload", "hello:world")
-          assert_equal("payload", client.receive.data)
-        end
+      ws_connect("valid") do |client|
+        client.receive
+        assert_equal 1, publish(channel_name, "payload", "hello:world")
+        assert_equal("payload", client.receive.data)
       end
     end
   end

--- a/test/support/goliath.rb
+++ b/test/support/goliath.rb
@@ -1,6 +1,8 @@
 require 'goliath/test_helper'
+require 'goliath/test_helper_ws'
 
 Goliath.env = RACK_ENV
+WebSocket.should_raise = true
 
 module Goliath
   module TestHelper

--- a/test/support/goliath.rb
+++ b/test/support/goliath.rb
@@ -9,5 +9,11 @@ module Goliath
         get_request(query_params, &blk)
       end
     end
+
+    def ws_connect(token, &blk)
+      with_api(Sinapse::Server) do
+        ws_client_connect("/?access_token=#{token}", &blk)
+      end
+    end
   end
 end

--- a/test/support/redis.rb
+++ b/test/support/redis.rb
@@ -5,6 +5,11 @@ module RedisTestHelper
     @redis ||= Redis.new(driver: 'synchrony', url: Sinapse.config.redis_url)
   end
 
+  def publish(channel, message, event = nil)
+    data = MessagePack.pack(event ? [event, message] : message)
+    redis.publish(channel, data)
+  end
+
   def publish_until_received
     EM.next_tick do
       notify = lambda do


### PR DESCRIPTION
Allows to connect using a WebSocket instead of EventSource (refs #4)

**Authentication**

Sends an initial `authentication: ok` text frame on success, or fails the handshake with a 401 HTTP Status.

**Messages**

Messages are always verbatim. Event names are always discarded, because WebSockets aren't an event protocol like EventSource can be —having them would require to specific a protocol format or force use of JSON or msgpack, which is out-of-scope for Sinapse.

**To Do**
- [x] send basic authentication message;
- [x] fail ws handshake with 401 unauthorized http status;
- [x] always send messages and never format event messages;
- [x] regularly ping the websockets to keep the connection alive.
