### PR TITLE
Catch published messages in testing (minitest)

### DIFF
--- a/lib/sinapse/publishable.rb
+++ b/lib/sinapse/publishable.rb
@@ -4,7 +4,9 @@ require 'msgpack'
 module Sinapse
   module Publishable
     def self.included(klass)
-      klass.__send__ :alias_method, :publish, :sinapse_publish unless klass.respond_to?(:publish)
+      unless klass.method_defined?(:publish)
+        klass.__send__(:define_method, :publish) { |*args| sinapse_publish(*args) }
+      end
     end
 
     def sinapse_publish(message, options = nil)

--- a/lib/sinapse/testing.rb
+++ b/lib/sinapse/testing.rb
@@ -1,0 +1,56 @@
+module Sinapse
+  def self.messages
+    @@messages ||= []
+  end
+
+  module Publishable
+    alias_method :sinapse_publish_orig, :sinapse_publish
+
+    def sinapse_publish(message, options = {})
+      if Sinapse::Testing.enabled?
+        Sinapse.messages << { message: message, event: options[:event] }
+      else
+        sinapse_publish_orig(message, options)
+      end
+    end
+  end
+
+  module Testing
+    def self.enabled?
+      !!@@enabled
+    end
+
+    def self.enable!
+      @@enabled = true
+    end
+
+    def self.disable!
+      @@enabled = false
+    end
+  end
+
+  module TestHelper
+    def self.included(klass)
+      if klass.respond_to?(:before)
+        klass.before { Sinapse.messages.clear }
+      elsif klass.respond_to?(:setup)
+        klass.setup { Sinapse.messages.clear } rescue nil
+      end
+    end
+
+    def assert_publishes(number = 1)
+      if block_given?
+        original_count = Sinapse.messages.size
+        yield
+        new_count = Sinapse.messages.size
+        assert_equal original_count + number, new_count, "#{number} messages expected, but #{new_count - original_count} were sent"
+      else
+        assert_equal number, Sinapse.messages.size
+      end
+    end
+
+    def refute_publishes(&block)
+      assert_publishes(0, &block)
+    end
+  end
+end

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "sinapse/testing"
+
+Sinapse::Testing.disable!
+
+describe "Sinapse::Testing" do
+  include Sinapse::TestHelper
+
+  before { Sinapse::Testing.enable! }
+  after { Sinapse::Testing.disable! }
+
+  let(:room) { Room.new(1) }
+
+  it "assert_publishes" do
+    assert_publishes(1) do
+      room.publish('hello room 1', event: "event_name")
+    end
+
+    assert_equal "event_name", Sinapse.messages.last[:event]
+    assert_equal "hello room 1", Sinapse.messages.last[:message]
+
+    assert_raises Minitest::Assertion do
+      assert_publishes {}
+    end
+  end
+
+  it "refute_publishes" do
+    refute_publishes {}
+
+    assert_raises Minitest::Assertion do
+      refute_publishes do
+        room.publish('hello room 1', event: "event_name")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example with Minitest Unit:

``` ruby
require "sinapse/testing"

class RoomTest < Minitest::Test
  include Sinapse::TestHelper

  def setup
    Sinapse::Testing.enable!
  end

  def teardown
    Sinapse::Testing.disable!
    Sinapse.messages.clear
  end

  def test_publishes_message
    assert_publishes(1) { rooms(:main).publish("message", event: "event") }
    assert_equal "event", Sinapse.messages.last[:event]
    assert_equal "message", Sinapse.messages.last[:message]

    refute_publishes {}
  end
end
```
