### PR TITLE
libcurl requires a minimum of 1 byte per elapsed second

### DIFF
--- a/lib/sinapse/config.rb
+++ b/lib/sinapse/config.rb
@@ -18,6 +18,10 @@ module Sinapse
       !ENV["SINAPSE_CHANNEL_EVENT"].nil?
     end
 
+    def libcurl
+      !ENV["SINAPSE_LIBCURL"].nil?
+    end
+
     private
 
       def default(name, default_value)

--- a/lib/sinapse/keep_alive.rb
+++ b/lib/sinapse/keep_alive.rb
@@ -18,8 +18,22 @@ module Sinapse
 
       def start
         EM.add_periodic_timer(Config.keep_alive) do
-          @queue.each { |env| env.chunked_stream_send ":\n" }
+          @queue.each { |env| env.chunked_stream_send comment }
         end
+      end
+
+      # NOTE: libcurl requires a minimum of 1 byte for each elapsed second to
+      #       keep the connection open. See CURLOPT_LOW_SPEED_LIMIT and
+      #       CURLOPT_LOW_SPEED_TIME for more informations.
+      #
+      #       We are sending more bytes here to avoid issues with high
+      #       latencies.
+      def comment
+        @comment ||= if Config.libcurl
+                       ":\n" * Config.keep_alive
+                     else
+                       ":\n"
+                     end
       end
   end
 end


### PR DESCRIPTION
With a certain configuration (low speed options) libcurl requires a minimum of 1 byte for each elapsed second until it timeouts the connection. Sinapse thus sends many comments at a regular interval to avoid this problem. Actually it's sending much more bytes to avoid high latency issues.

This feature isn't enabled by default and requires the `SINAPSE_LIBCURL` environment variable to be set.

I only recommend it for faster development purposes, because it affects all connections and it's a libcurl limitation. You are advised to either not use libcurl, or to disable the low speed limits, and roll your own watcher that checks that a at least one comment was received for a given interval.
